### PR TITLE
PDF Feature for Public Dashboard

### DIFF
--- a/Home.py
+++ b/Home.py
@@ -2,8 +2,6 @@ from kailo_beewell_dashboard.images import get_image_path
 from kailo_beewell_dashboard.page_setup import blank_lines, page_footer, page_setup
 import pickle
 import streamlit as st
-import weasyprint
-from tempfile import NamedTemporaryFile
 
 page_setup("public")
 
@@ -48,98 +46,8 @@ dashboard
 * **Standard survey** - Explore overall topic scores by area, and view
 the responses to each question overall or by pupil characteristics.
 * **Symbol survey** - Explore responses to the ten questions overall or
-by pupil characteristics.""")
-
-blank_lines(2)
-
-# Section for downloading PDF report
-st.subheader("Download PDF report")
-st.markdown("""
-You can use the interactive dashboards to explore results. We
-also provide the option of downloading a PDF version of the results below.""")
-
-# Create content for public pdf reports (TO BE ADDED TO static_report.py IN PACKAGES)
-
-# Create content for public standard survey
-def create_static_public_report(report_type):
-
-    """
-    Generate a static PDF report for the standard survey results
-
-    Parameters
-     ----------
-    chosen_school : string
-        Name of the chosen school
-    chosen_group : string
-        Name of the chosen group to view results by - options are
-        'For all pupils', 'By year group', 'By gender', 'By FSM' or 'By SEN'
-    df_scores : dataframe
-        Dataframe with aggregate scores and RAG for each topic
-    df_prop : dataframe
-        Dataframe with proportion of each response to each survey question
-    counts : dataframe
-        Dataframe with the counts of pupils at each school
-    dem_prop : dataframe
-        Dataframe with proportion of each reponse to the demographic questions
-    pdf_title : string
-        Title for the PDF file"""
-    
-
-# Create content for public symbol survey
-
-
-def generate_static_public_report(report_type):
-    with st.spinner(f"Generating {report_type} report"):
-        st.session_state.html_content = "<h1>Standard survey report</h1>"
-        # Convert to temporary PDF file, then read PDF back into
-        # environment and store report in the session state
-        with NamedTemporaryFile(suffix=".pdf") as temp:
-            weasyprint.HTML(string=st.session_state.html_content).write_pdf(temp)
-            temp.seek(0)
-            st.session_state[f"pdf_report_{report_type}"] = open(temp.name, "rb")
-
-
-def generate_static_symbol_public_report(report_type):
-    with st.spinner(f"Generating {report_type} report"):
-        st.session_state.html_content = "<h1>Symbol survey report</h1>"
-        # Convert to temporary PDF file, then read PDF back into
-        # environment and store report in the session state
-        with NamedTemporaryFile(suffix=".pdf") as temp:
-            weasyprint.HTML(string=st.session_state.html_content).write_pdf(temp)
-            temp.seek(0)
-            st.session_state[f"pdf_report_{report_type}"] = open(temp.name, "rb")
-
-
-# Re-run script, so the generate button is removed
-# st.experimental_rerun()
-
-
-# Button to generate standard survey report
-if "pdf_report_standard" not in st.session_state:
-    if st.button("Generate standard survey report - this will take around 30 seconds"):
-        generate_static_public_report("standard")
-
-# Button to generate symbol survey report
-if "pdf_report_symbol" not in st.session_state:
-    if st.button("Generate symbol survey report - this will take around 30 seconds"):
-        generate_static_symbol_public_report("symbol")
-
-# If report has been generated, show download buttons
-if "pdf_report_standard" in st.session_state:
-    st.download_button(
-        label="Download standard survey report",
-        data=st.session_state["pdf_report_standard"],
-        file_name="kailo_beewell_school_report_standard.pdf",
-        mime="application/pdf",
-    )
-
-if "pdf_report_symbol" in st.session_state:
-    st.download_button(
-        label="Download symbol survey report",
-        data=st.session_state["pdf_report_symbol"],
-        file_name="kailo_beewell_school_report_symbol.pdf",
-        mime="application/pdf",
-    )
+by pupil characteristics.
+* **Download PDF reports** - Export reports as PDF files.""")
 
 blank_lines(2)
 

--- a/Home.py
+++ b/Home.py
@@ -1,29 +1,32 @@
 from kailo_beewell_dashboard.images import get_image_path
-from kailo_beewell_dashboard.page_setup import (
-    blank_lines, page_footer, page_setup)
+from kailo_beewell_dashboard.page_setup import blank_lines, page_footer, page_setup
 import pickle
 import streamlit as st
+import weasyprint
+from tempfile import NamedTemporaryFile
 
-page_setup('public')
+page_setup("public")
 
 # Import data
-with open('data/survey_data/nd_overall_counts.pkl', 'rb') as f:
+with open("data/survey_data/nd_overall_counts.pkl", "rb") as f:
     school_counts = pickle.load(f)
 
 # Title and sub-title
-st.title('The #BeeWell Survey')
-st.markdown('''
+st.title("The #BeeWell Survey")
+st.markdown(
+    """
 <p style='text-align: center; font-weight: bold'>
 This dashboard shares results from the #BeeWell survey<br>delivered by Kailo
 in Northern Devon.</p>
-''', unsafe_allow_html=True)
+""",
+    unsafe_allow_html=True,
+)
 
 # Image
-st.image(get_image_path('home_image_3_transparent.png'),
-         use_column_width=True)
+st.image(get_image_path("home_image_3_transparent.png"), use_column_width=True)
 
 # Introduction
-st.markdown(f'''In the academic year 2023-24, {school_counts['total_pupils']}
+st.markdown(f"""In the academic year 2023-24, {school_counts['total_pupils']}
 pupils from {school_counts['total_schools']} schools across North Devon and
 Torridge took part in the #BeeWell survey delivered by Kailo. There were
 two versions of the survey:
@@ -31,13 +34,13 @@ two versions of the survey:
 pupils in Years 8 and 10 at {school_counts['standard_schools']} mainstream
 schools
 * Symbol #BeeWell survey - completed by {school_counts['symbol_pupils']} pupils
-Years 7 to 11 at {school_counts['symbol_schools']} non-mainstream schools''')
+Years 7 to 11 at {school_counts['symbol_schools']} non-mainstream schools""")
 
 blank_lines(2)
 
 # Pages of the dashboard
-st.subheader('What each page of the dashboard can tell you')
-st.markdown('''
+st.subheader("What each page of the dashboard can tell you")
+st.markdown("""
 There are six pages to see on this dashboard, which you can navigate to using
 the sidebar on the left. These are:
 * **About** - Read information on the #BeeWell survey, Kailo, and this
@@ -45,23 +48,108 @@ dashboard
 * **Standard survey** - Explore overall topic scores by area, and view
 the responses to each question overall or by pupil characteristics.
 * **Symbol survey** - Explore responses to the ten questions overall or
-by pupil characteristics.''')
+by pupil characteristics.""")
 
 blank_lines(2)
 
 # Section for downloading PDF report
-st.subheader('Download PDF report')
-st.markdown('tbc')
+st.subheader("Download PDF report")
+st.markdown("""
+You can use the interactive dashboards to explore results. We
+also provide the option of downloading a PDF version of the results below.""")
+
+# Create content for public pdf reports (TO BE ADDED TO static_report.py IN PACKAGES)
+
+# Create content for public standard survey
+def create_static_public_report(report_type):
+
+    """
+    Generate a static PDF report for the standard survey results
+
+    Parameters
+     ----------
+    chosen_school : string
+        Name of the chosen school
+    chosen_group : string
+        Name of the chosen group to view results by - options are
+        'For all pupils', 'By year group', 'By gender', 'By FSM' or 'By SEN'
+    df_scores : dataframe
+        Dataframe with aggregate scores and RAG for each topic
+    df_prop : dataframe
+        Dataframe with proportion of each response to each survey question
+    counts : dataframe
+        Dataframe with the counts of pupils at each school
+    dem_prop : dataframe
+        Dataframe with proportion of each reponse to the demographic questions
+    pdf_title : string
+        Title for the PDF file"""
+    
+
+# Create content for public symbol survey
+
+
+def generate_static_public_report(report_type):
+    with st.spinner(f"Generating {report_type} report"):
+        st.session_state.html_content = "<h1>Standard survey report</h1>"
+        # Convert to temporary PDF file, then read PDF back into
+        # environment and store report in the session state
+        with NamedTemporaryFile(suffix=".pdf") as temp:
+            weasyprint.HTML(string=st.session_state.html_content).write_pdf(temp)
+            temp.seek(0)
+            st.session_state[f"pdf_report_{report_type}"] = open(temp.name, "rb")
+
+
+def generate_static_symbol_public_report(report_type):
+    with st.spinner(f"Generating {report_type} report"):
+        st.session_state.html_content = "<h1>Symbol survey report</h1>"
+        # Convert to temporary PDF file, then read PDF back into
+        # environment and store report in the session state
+        with NamedTemporaryFile(suffix=".pdf") as temp:
+            weasyprint.HTML(string=st.session_state.html_content).write_pdf(temp)
+            temp.seek(0)
+            st.session_state[f"pdf_report_{report_type}"] = open(temp.name, "rb")
+
+
+# Re-run script, so the generate button is removed
+# st.experimental_rerun()
+
+
+# Button to generate standard survey report
+if "pdf_report_standard" not in st.session_state:
+    if st.button("Generate standard survey report - this will take around 30 seconds"):
+        generate_static_public_report("standard")
+
+# Button to generate symbol survey report
+if "pdf_report_symbol" not in st.session_state:
+    if st.button("Generate symbol survey report - this will take around 30 seconds"):
+        generate_static_symbol_public_report("symbol")
+
+# If report has been generated, show download buttons
+if "pdf_report_standard" in st.session_state:
+    st.download_button(
+        label="Download standard survey report",
+        data=st.session_state["pdf_report_standard"],
+        file_name="kailo_beewell_school_report_standard.pdf",
+        mime="application/pdf",
+    )
+
+if "pdf_report_symbol" in st.session_state:
+    st.download_button(
+        label="Download symbol survey report",
+        data=st.session_state["pdf_report_symbol"],
+        file_name="kailo_beewell_school_report_symbol.pdf",
+        mime="application/pdf",
+    )
 
 blank_lines(2)
 
 # #BeeWell pupil video
-st.subheader('Introduction to the survey')
-st.markdown('''
+st.subheader("Introduction to the survey")
+st.markdown("""
 If you're unfamiliar with the #BeeWell survey or would like a reminder, you can
 check out the video below. This video (which was designed for pupils) explains
 what pupils could expect from taking part in the survey. For more information,
-see the 'About' page of the dashboard.''')
-st.video('https://youtu.be/jmYH7F2Bd4Q')
+see the 'About' page of the dashboard.""")
+st.video("https://youtu.be/jmYH7F2Bd4Q")
 
-page_footer('schools in Northern Devon')
+page_footer("schools in Northern Devon")

--- a/pages/4_Download PDF reports.py
+++ b/pages/4_Download PDF reports.py
@@ -9,16 +9,15 @@ import weasyprint
 from tempfile import NamedTemporaryFile
 
 # Initialise the session state for report generation
-if "generating_standard_report" not in st.session_state:
-    st.session_state["generating_standard_report"] = False
-if "pdf_report_generated" not in st.session_state:
-    st.session_state["pdf_report_generated"] = False
+if "pdf_report_standard" not in st.session_state:
+    st.session_state["pdf_report_standard"] = None
+if "pdf_report_standard_generated" not in st.session_state:
+    st.session_state["pdf_report_standard_generated"] = False
 
-if "generating_symbol_report" not in st.session_state:
-    st.session_state["generating_symbol_report"] = False
-if "symbol_report_generated" not in st.session_state:
-    st.session_state["symbol_report_generated"] = False
-
+if "pdf_report_symbol" not in st.session_state:
+    st.session_state["pdf_report_symbol"] = None
+if "pdf_report_symbol_generated" not in st.session_state:
+    st.session_state["pdf_report_symbol_generated"] = False
 
 page_setup("public")
 
@@ -91,17 +90,15 @@ def create_static_public_report(report_type):
     return html_content
 
 
-def generate_static_public_report(report_type):
-    with st.spinner(f"Generating {report_type} report"):
-        html_content = create_static_public_report(report_type)
+# Function to generate the standard report
+def generate_static_public_report():
+    with st.spinner("Generating standard report..."):
+        html_content = create_static_public_report("standard")
         with NamedTemporaryFile(suffix=".pdf") as temp:
             weasyprint.HTML(string=html_content).write_pdf(temp)
             temp.seek(0)
-            st.session_state[f"pdf_report_{report_type}"] = open(temp.name, "rb")
-        st.session_state["generating_standard_report"] = (
-            False  # Reset state after generation
-        )
-        st.session_state["pdf_report_generated"] = True  # Mark report as generated
+            st.session_state["pdf_report_standard"] = temp.read()
+        st.session_state["pdf_report_standard_generated"] = True
 
 
 # Create content for public symbol survey
@@ -161,32 +158,25 @@ def create_static_symbol_report(report_type):
     return html_content
 
 
-def generate_static_symbol_report(report_type):
-    with st.spinner(f"Generating {report_type} report"):
-        html_content = create_static_symbol_report(report_type)
+# Function to generate the symbol report
+def generate_static_symbol_report():
+    with st.spinner("Generating symbol report..."):
+        html_content = create_static_symbol_report("symbol")
         with NamedTemporaryFile(suffix=".pdf") as temp:
             weasyprint.HTML(string=html_content).write_pdf(temp)
             temp.seek(0)
-            st.session_state[f"pdf_report_{report_type}"] = open(temp.name, "rb")
-        st.session_state["generating_symbol_report"] = (
-            False  # Reset state after generation
-        )
-        st.session_state["symbol_report_generated"] = True  # Mark report as generated
+            st.session_state["pdf_report_symbol"] = temp.read()
+        st.session_state["pdf_report_symbol_generated"] = True
 
 
-st.markdown("""
-**The standard survey**""")
+st.markdown("**The standard survey**")
 
 # Button to generate standard survey report
-if not st.session_state["pdf_report_generated"]:
-    if st.button(
-        "💡 Generate standard survey report - this will take around 30 seconds"
-    ):
-        st.session_state["generating_standard_report"] = True
-        generate_static_public_report("standard")
+if st.button("💡 Generate standard survey report - this will take around 30 seconds"):
+    generate_static_public_report()
 
-# If report has been generated, show download button
-if st.session_state["pdf_report_generated"]:
+# Show the download button if the standard report is generated
+if st.session_state["pdf_report_standard_generated"]:
     st.download_button(
         label="⬇️ Download standard survey report",
         data=st.session_state["pdf_report_standard"],
@@ -194,23 +184,19 @@ if st.session_state["pdf_report_generated"]:
         mime="application/pdf",
     )
 
-st.markdown("""
-**The symbol survey**""")
+st.markdown("**The symbol survey**")
 
 # Button to generate symbol survey report
-if not st.session_state["symbol_report_generated"]:
-    if st.button("💡 Generate symbol survey report - this will take around 30 seconds"):
-        st.session_state["generating_symbol_report"] = True
-        generate_static_symbol_report("symbol")
+if st.button("💡 Generate symbol survey report - this will take around 30 seconds"):
+    generate_static_symbol_report()
 
-# If report has been generated, show download button
-if st.session_state["symbol_report_generated"]:
+# Show the download button if the symbol report is generated
+if st.session_state["pdf_report_symbol_generated"]:
     st.download_button(
         label="⬇️ Download symbol survey report",
         data=st.session_state["pdf_report_symbol"],
         file_name="kailo_beewell_school_report_symbol.pdf",
         mime="application/pdf",
     )
-
 
 page_footer("schools in Northern Devon")

--- a/pages/4_Download PDF reports.py
+++ b/pages/4_Download PDF reports.py
@@ -1,13 +1,21 @@
 from kailo_beewell_dashboard.page_setup import blank_lines, page_footer, page_setup
+from kailo_beewell_dashboard.static_report import (
+    logo_html,
+    illustration_html,
+    structure_report,
+)
 import streamlit as st
 import weasyprint
 from tempfile import NamedTemporaryFile
+import base64
+from importlib.resources import files
+import os
+
 
 page_setup("public")
 
 # Title and introduction
 st.title("Download PDF reports")
-
 
 # Section for downloading PDF report
 st.subheader("Generate PDF report to download")
@@ -39,36 +47,152 @@ def create_static_public_report(report_type):
     dem_prop : dataframe
         Dataframe with proportion of each reponse to the demographic questions
     pdf_title : string
-        Title for the PDF file"""
+        Title for the PDF file
+    """
+    content = []
+    pdf_title = "Public Dashboard Report"
 
+    # Title Page
+    content.append(logo_html())
+    title_page = """
+<div class='section_container'>
+    <h1 style='text-align:center;'>#BeeWell - The Standard Survey</h1>
+    <p style='text-align:center; font-weight:bold;'>Thank you for taking part in the #BeeWell survey delivered by Kailo.</p>
+    <p>The results from pupils can be explored using the interactive dashboard. This report has been downloaded from that dashboard.</p>
+</div>
+"""
+    content.append(title_page)
+    content.append(illustration_html())
 
-# Create content for public symbol survey
+    # Introduction
+    content.append('<h1 style="page-break-before:always;">Introduction</h1>')
+    content.append("<h2>How to use this report</h2>")
+    content.append(
+        "<p>Explanation of how to use the report...</p>"
+    )  # Replace with actual content
+    content.append("<h2>Comparing between areas</h2>")
+    content.append(
+        "<p>Important notes on comparing data...</p>"
+    )  # Replace with actual content
+
+    # Table of Contents
+    content.append('<h1 style="page-break-before:always;">Table of Contents</h1>')
+    content.append(
+        '<ul><li><a href="#summary">Summary</a></li><li><a href="#explore_results">Explore results</a></li><li><a href="#who_took_part">Who took part</a></li></ul>'
+    )
+
+    # Summary
+    content.append('<h1 id="summary" style="page-break-before:always;">Summary</h1>')
+    content.append("<p>Summary of the results...</p>")  # Replace with actual content
+
+    # Explore Results
+    content.append(
+        '<h1 id="explore_results" style="page-break-before:always;">Explore Results</h1>'
+    )
+    content.append(
+        "<p>Detailed exploration of results...</p>"
+    )  # Replace with actual content
+
+    # Who Took Part
+    content.append(
+        '<h1 id="who_took_part" style="page-break-before:always;">Who Took Part</h1>'
+    )
+    content.append("<p>Demographic information...</p>")  # Replace with actual content
+
+    # Create HTML report
+    html_content = structure_report(pdf_title, content)
+    return html_content
 
 
 def generate_static_public_report(report_type):
     with st.spinner(f"Generating {report_type} report"):
-        st.session_state.html_content = "<h1>Standard survey report</h1>"
-        # Convert to temporary PDF file, then read PDF back into
-        # environment and store report in the session state
+        html_content = create_static_public_report(report_type)
         with NamedTemporaryFile(suffix=".pdf") as temp:
-            weasyprint.HTML(string=st.session_state.html_content).write_pdf(temp)
+            weasyprint.HTML(string=html_content).write_pdf(temp)
             temp.seek(0)
             st.session_state[f"pdf_report_{report_type}"] = open(temp.name, "rb")
 
 
-def generate_static_symbol_public_report(report_type):
+# Create content for public symbol survey
+def create_static_symbol_report(report_type):
+    """
+    Generate a static PDF report for the symbol survey results
+
+    Parameters
+     ----------
+    chosen_school : string
+        Name of the chosen school
+    df_prop : dataframe
+        Dataframe with proportion of each response to each survey question
+    counts : dataframe
+        Dataframe with the counts of pupils at each school
+    dem_prop : dataframe
+        Dataframe with proportion of each reponse to the demographic questions
+    pdf_title : string
+        Title for the PDF file
+    """
+    content = []
+    pdf_title = "Symbol Survey Report"
+
+    # Title Page
+    content.append(logo_html())
+    title_page = """
+<div class='section_container'>
+    <h1 style='text-align:center;'>#BeeWell - The Symbol Survey</h1>
+    <p style='text-align:center; font-weight:bold;'>Thank you for taking part in the #BeeWell survey delivered by Kailo.</p>
+    <p>The results from pupils can be explored using the interactive dashboard. This report has been downloaded from that dashboard.</p>
+</div>
+"""
+    content.append(title_page)
+    content.append(illustration_html())
+
+    # Introduction
+    content.append('<h1 style="page-break-before:always;">Introduction</h1>')
+    content.append("<h2>How to use this report</h2>")
+    content.append(
+        "<p>Explanation of how to use the report...</p>"
+    )  # Replace with actual content
+    content.append("<h2>Comparing between areas</h2>")
+    content.append(
+        "<p>Important notes on comparing data...</p>"
+    )  # Replace with actual content
+
+    # Table of Contents
+    content.append('<h1 style="page-break-before:always;">Table of Contents</h1>')
+    content.append(
+        '<ul><li><a href="#summary">Summary</a></li><li><a href="#explore_results">Explore results</a></li><li><a href="#who_took_part">Who took part</a></li></ul>'
+    )
+
+    # Summary
+    content.append('<h1 id="summary" style="page-break-before:always;">Summary</h1>')
+    content.append("<p>Summary of the results...</p>")  # Replace with actual content
+
+    # Explore Results
+    content.append(
+        '<h1 id="explore_results" style="page-break-before:always;">Explore Results</h1>'
+    )
+    content.append(
+        "<p>Detailed exploration of results...</p>"
+    )  # Replace with actual content
+
+    # Who Took Part
+    content.append(
+        '<h1 id="who_took_part" style="page-break-before:always;">Who Took Part</h1>'
+    )
+    content.append("<p>Demographic information...</p>")  # Replace with actual content
+
+    # Create HTML report
+    html_content = structure_report(pdf_title, content)
+    return html_content
+
+
+def generate_static_symbol_report(report_type):
     with st.spinner(f"Generating {report_type} report"):
-        st.session_state.html_content = "<h1>Symbol survey report</h1>"
-        # Convert to temporary PDF file, then read PDF back into
-        # environment and store report in the session state
+        html_content = create_static_symbol_report(report_type)
         with NamedTemporaryFile(suffix=".pdf") as temp:
-            weasyprint.HTML(string=st.session_state.html_content).write_pdf(temp)
+            weasyprint.HTML(string=html_content).write_pdf(temp)
             temp.seek(0)
             st.session_state[f"pdf_report_{report_type}"] = open(temp.name, "rb")
-
-
-# Re-run script, so the generate button is removed
-# st.experimental_rerun()
 
 
 # Button to generate standard survey report
@@ -79,7 +203,7 @@ if "pdf_report_standard" not in st.session_state:
 # Button to generate symbol survey report
 if "pdf_report_symbol" not in st.session_state:
     if st.button("Generate symbol survey report - this will take around 30 seconds"):
-        generate_static_symbol_public_report("symbol")
+        generate_static_symbol_report("symbol")
 
 # If report has been generated, show download buttons
 if "pdf_report_standard" in st.session_state:

--- a/pages/4_Download PDF reports.py
+++ b/pages/4_Download PDF reports.py
@@ -8,6 +8,17 @@ import streamlit as st
 import weasyprint
 from tempfile import NamedTemporaryFile
 
+# Initialise the session state for report generation
+if "generating_standard_report" not in st.session_state:
+    st.session_state["generating_standard_report"] = False
+if "pdf_report_generated" not in st.session_state:
+    st.session_state["pdf_report_generated"] = False
+
+if "generating_symbol_report" not in st.session_state:
+    st.session_state["generating_symbol_report"] = False
+if "symbol_report_generated" not in st.session_state:
+    st.session_state["symbol_report_generated"] = False
+
 
 page_setup("public")
 
@@ -25,27 +36,6 @@ also provide the option of downloading a PDF version of the results below.""")
 
 # Create content for public standard survey
 def create_static_public_report(report_type):
-    """
-    Generate a static PDF report for the standard survey results
-
-    Parameters
-     ----------
-    chosen_school : string
-        Name of the chosen school
-    chosen_group : string
-        Name of the chosen group to view results by - options are
-        'For all pupils', 'By year group', 'By gender', 'By FSM' or 'By SEN'
-    df_scores : dataframe
-        Dataframe with aggregate scores and RAG for each topic
-    df_prop : dataframe
-        Dataframe with proportion of each response to each survey question
-    counts : dataframe
-        Dataframe with the counts of pupils at each school
-    dem_prop : dataframe
-        Dataframe with proportion of each reponse to the demographic questions
-    pdf_title : string
-        Title for the PDF file
-    """
     content = []
     pdf_title = "Public Dashboard Report"
 
@@ -108,26 +98,14 @@ def generate_static_public_report(report_type):
             weasyprint.HTML(string=html_content).write_pdf(temp)
             temp.seek(0)
             st.session_state[f"pdf_report_{report_type}"] = open(temp.name, "rb")
+        st.session_state["generating_standard_report"] = (
+            False  # Reset state after generation
+        )
+        st.session_state["pdf_report_generated"] = True  # Mark report as generated
 
 
 # Create content for public symbol survey
 def create_static_symbol_report(report_type):
-    """
-    Generate a static PDF report for the symbol survey results
-
-    Parameters
-     ----------
-    chosen_school : string
-        Name of the chosen school
-    df_prop : dataframe
-        Dataframe with proportion of each response to each survey question
-    counts : dataframe
-        Dataframe with the counts of pupils at each school
-    dem_prop : dataframe
-        Dataframe with proportion of each reponse to the demographic questions
-    pdf_title : string
-        Title for the PDF file
-    """
     content = []
     pdf_title = "Symbol Survey Report"
 
@@ -190,42 +168,49 @@ def generate_static_symbol_report(report_type):
             weasyprint.HTML(string=html_content).write_pdf(temp)
             temp.seek(0)
             st.session_state[f"pdf_report_{report_type}"] = open(temp.name, "rb")
+        st.session_state["generating_symbol_report"] = (
+            False  # Reset state after generation
+        )
+        st.session_state["symbol_report_generated"] = True  # Mark report as generated
 
 
 st.markdown("""
 **The standard survey**""")
 
 # Button to generate standard survey report
-if "pdf_report_standard" not in st.session_state:
+if not st.session_state["pdf_report_generated"]:
     if st.button(
         "💡 Generate standard survey report - this will take around 30 seconds"
     ):
+        st.session_state["generating_standard_report"] = True
         generate_static_public_report("standard")
 
 # If report has been generated, show download button
-if "pdf_report_standard" in st.session_state:
+if st.session_state["pdf_report_generated"]:
     st.download_button(
         label="⬇️ Download standard survey report",
         data=st.session_state["pdf_report_standard"],
         file_name="kailo_beewell_school_report_standard.pdf",
         mime="application/pdf",
     )
-blank_lines(2)
 
 st.markdown("""
 **The symbol survey**""")
+
 # Button to generate symbol survey report
-if "pdf_report_symbol" not in st.session_state:
-    if st.button("Generate symbol survey report - this will take around 30 seconds"):
+if not st.session_state["symbol_report_generated"]:
+    if st.button("💡 Generate symbol survey report - this will take around 30 seconds"):
+        st.session_state["generating_symbol_report"] = True
         generate_static_symbol_report("symbol")
 
 # If report has been generated, show download button
-if "pdf_report_symbol" in st.session_state:
+if st.session_state["symbol_report_generated"]:
     st.download_button(
-        label="Download symbol survey report",
+        label="⬇️ Download symbol survey report",
         data=st.session_state["pdf_report_symbol"],
         file_name="kailo_beewell_school_report_symbol.pdf",
         mime="application/pdf",
     )
+
 
 page_footer("schools in Northern Devon")

--- a/pages/4_Download PDF reports.py
+++ b/pages/4_Download PDF reports.py
@@ -1,0 +1,101 @@
+from kailo_beewell_dashboard.page_setup import blank_lines, page_footer, page_setup
+import streamlit as st
+import weasyprint
+from tempfile import NamedTemporaryFile
+
+page_setup("public")
+
+# Title and introduction
+st.title("Download PDF reports")
+
+
+# Section for downloading PDF report
+st.subheader("Generate PDF report to download")
+st.markdown("""
+You can use the interactive dashboards to explore results. We
+also provide the option of downloading a PDF version of the results below.""")
+
+# Create content for public pdf reports (TO BE ADDED TO static_report.py IN PACKAGES)
+
+
+# Create content for public standard survey
+def create_static_public_report(report_type):
+    """
+    Generate a static PDF report for the standard survey results
+
+    Parameters
+     ----------
+    chosen_school : string
+        Name of the chosen school
+    chosen_group : string
+        Name of the chosen group to view results by - options are
+        'For all pupils', 'By year group', 'By gender', 'By FSM' or 'By SEN'
+    df_scores : dataframe
+        Dataframe with aggregate scores and RAG for each topic
+    df_prop : dataframe
+        Dataframe with proportion of each response to each survey question
+    counts : dataframe
+        Dataframe with the counts of pupils at each school
+    dem_prop : dataframe
+        Dataframe with proportion of each reponse to the demographic questions
+    pdf_title : string
+        Title for the PDF file"""
+
+
+# Create content for public symbol survey
+
+
+def generate_static_public_report(report_type):
+    with st.spinner(f"Generating {report_type} report"):
+        st.session_state.html_content = "<h1>Standard survey report</h1>"
+        # Convert to temporary PDF file, then read PDF back into
+        # environment and store report in the session state
+        with NamedTemporaryFile(suffix=".pdf") as temp:
+            weasyprint.HTML(string=st.session_state.html_content).write_pdf(temp)
+            temp.seek(0)
+            st.session_state[f"pdf_report_{report_type}"] = open(temp.name, "rb")
+
+
+def generate_static_symbol_public_report(report_type):
+    with st.spinner(f"Generating {report_type} report"):
+        st.session_state.html_content = "<h1>Symbol survey report</h1>"
+        # Convert to temporary PDF file, then read PDF back into
+        # environment and store report in the session state
+        with NamedTemporaryFile(suffix=".pdf") as temp:
+            weasyprint.HTML(string=st.session_state.html_content).write_pdf(temp)
+            temp.seek(0)
+            st.session_state[f"pdf_report_{report_type}"] = open(temp.name, "rb")
+
+
+# Re-run script, so the generate button is removed
+# st.experimental_rerun()
+
+
+# Button to generate standard survey report
+if "pdf_report_standard" not in st.session_state:
+    if st.button("Generate standard survey report - this will take around 30 seconds"):
+        generate_static_public_report("standard")
+
+# Button to generate symbol survey report
+if "pdf_report_symbol" not in st.session_state:
+    if st.button("Generate symbol survey report - this will take around 30 seconds"):
+        generate_static_symbol_public_report("symbol")
+
+# If report has been generated, show download buttons
+if "pdf_report_standard" in st.session_state:
+    st.download_button(
+        label="Download standard survey report",
+        data=st.session_state["pdf_report_standard"],
+        file_name="kailo_beewell_school_report_standard.pdf",
+        mime="application/pdf",
+    )
+
+if "pdf_report_symbol" in st.session_state:
+    st.download_button(
+        label="Download symbol survey report",
+        data=st.session_state["pdf_report_symbol"],
+        file_name="kailo_beewell_school_report_symbol.pdf",
+        mime="application/pdf",
+    )
+
+page_footer("schools in Northern Devon")

--- a/pages/4_Download PDF reports.py
+++ b/pages/4_Download PDF reports.py
@@ -7,9 +7,6 @@ from kailo_beewell_dashboard.static_report import (
 import streamlit as st
 import weasyprint
 from tempfile import NamedTemporaryFile
-import base64
-from importlib.resources import files
-import os
 
 
 page_setup("public")
@@ -195,25 +192,34 @@ def generate_static_symbol_report(report_type):
             st.session_state[f"pdf_report_{report_type}"] = open(temp.name, "rb")
 
 
+st.markdown("""
+**The standard survey**""")
+
 # Button to generate standard survey report
 if "pdf_report_standard" not in st.session_state:
-    if st.button("Generate standard survey report - this will take around 30 seconds"):
+    if st.button(
+        "💡 Generate standard survey report - this will take around 30 seconds"
+    ):
         generate_static_public_report("standard")
 
+# If report has been generated, show download button
+if "pdf_report_standard" in st.session_state:
+    st.download_button(
+        label="⬇️ Download standard survey report",
+        data=st.session_state["pdf_report_standard"],
+        file_name="kailo_beewell_school_report_standard.pdf",
+        mime="application/pdf",
+    )
+blank_lines(2)
+
+st.markdown("""
+**The symbol survey**""")
 # Button to generate symbol survey report
 if "pdf_report_symbol" not in st.session_state:
     if st.button("Generate symbol survey report - this will take around 30 seconds"):
         generate_static_symbol_report("symbol")
 
-# If report has been generated, show download buttons
-if "pdf_report_standard" in st.session_state:
-    st.download_button(
-        label="Download standard survey report",
-        data=st.session_state["pdf_report_standard"],
-        file_name="kailo_beewell_school_report_standard.pdf",
-        mime="application/pdf",
-    )
-
+# If report has been generated, show download button
 if "pdf_report_symbol" in st.session_state:
     st.download_button(
         label="Download symbol survey report",


### PR DESCRIPTION
Added new page for creating and downloading PDF reports for standard and symbol survey. PDFs generated are currently tamplates only with placeholders for content. Content of PDFs needs to be finalised (once all features of dashboard have been completed) and the code for this needs to be added to the package.